### PR TITLE
Refactor firmware into modules with status LED and braking

### DIFF
--- a/include/buzzer_controller.h
+++ b/include/buzzer_controller.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Arduino.h>
+#include <cstddef>
+#include <cstdint>
+
+struct ToneStep {
+  uint16_t frequencyHz;
+  uint16_t durationMs;
+  uint16_t pauseMs;
+};
+
+template <std::size_t N>
+constexpr std::size_t ToneSequenceLength(const ToneStep (&)[N]) {
+  return N;
+}
+
+class BuzzerController {
+public:
+  void begin(uint8_t pin, uint8_t channel, uint8_t resolutionBits);
+  void update();
+  void playSequence(const ToneStep *sequence, std::size_t length, bool loop = false);
+  void stop();
+  bool isPlaying() const;
+
+private:
+  void loadNextStep();
+
+  uint8_t channel_ = 0;
+  uint8_t resolutionBits_ = 0;
+  bool playing_ = false;
+  bool looping_ = false;
+  bool inPause_ = false;
+  const ToneStep *sequence_ = nullptr;
+  std::size_t length_ = 0;
+  std::size_t currentIndex_ = 0;
+  uint32_t nextChangeMs_ = 0;
+  uint16_t pendingPauseMs_ = 0;
+};
+

--- a/include/control_protocol.h
+++ b/include/control_protocol.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "device_config.h"
+
+namespace protocol {
+
+enum class MessageType : uint8_t {
+  kScanRequest = 0x01,
+  kDroneIdentity = 0x02,
+  kControllerIdentity = 0x03,
+  kDroneAck = 0x04,
+  kControlCommand = 0x10,
+};
+
+#pragma pack(push, 1)
+struct IdentityMessage {
+  uint8_t type;
+  char identity[16];
+  uint8_t mac[6];
+};
+
+struct ControlMessage {
+  uint8_t type;
+  uint8_t version;
+  uint32_t sequence;
+  int16_t motorDuty[config::kMotorCount];
+  uint16_t flags;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(IdentityMessage) == 23, "IdentityMessage must match ILITE discovery payload size");
+static_assert(sizeof(ControlMessage) == 16, "ControlMessage layout must stay byte-packed for ESP-NOW");
+
+constexpr uint8_t kControlProtocolVersion = 1;
+constexpr uint16_t kControlFlagHonk = 0x0001;
+constexpr uint16_t kControlFlagBrakeBase = 0x0010;
+
+inline constexpr uint16_t BrakeFlagForMotor(std::size_t index) {
+  return static_cast<uint16_t>(kControlFlagBrakeBase << index);
+}
+
+} // namespace protocol

--- a/include/control_system.h
+++ b/include/control_system.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+
+#include "buzzer_controller.h"
+#include "control_protocol.h"
+#include "device_config.h"
+#include "motor_driver.h"
+#include "status_led.h"
+
+class ControlSystem {
+public:
+  void begin();
+  void loop();
+  void onEspNowData(const uint8_t *mac, const uint8_t *data, int len);
+
+private:
+  struct PairingState {
+    bool paired = false;
+    uint8_t controllerMac[6] = {0};
+    char controllerName[16] = {0};
+  };
+
+  static void EspNowReceiveTrampoline(const uint8_t *mac, const uint8_t *data, int len);
+
+  void handleScanRequest(const uint8_t *mac);
+  void handleControllerIdentity(const uint8_t *mac, const protocol::IdentityMessage &message);
+  void handleControlPacket(const uint8_t *mac, const protocol::ControlMessage &packet);
+  void ensurePeer(const uint8_t *mac);
+  void sendIdentityMessage(const uint8_t *mac, protocol::MessageType type);
+  void stopAllMotors();
+  void enterFailsafe();
+  void exitFailsafe();
+  void updateDriveIndicator();
+  void updateStatusForPairing();
+  void updateStatusForConnection();
+
+  MotorDriver motors_[config::kMotorCount];
+  BuzzerController buzzer_;
+  StatusLed statusLed_;
+  PairingState pairingState_;
+  uint32_t lastControlTimestamp_ = 0;
+  bool failsafeActive_ = false;
+  bool pendingPairingTone_ = false;
+  float lastMotorCommands_[config::kMotorCount] = {0};
+
+  static ControlSystem *instance_;
+};
+

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace config {
+
+constexpr const char kDeviceIdentity[] = "Thegiller-PT12";
+constexpr const char kAccessPointSsid[] = "Thegill PORT";
+constexpr const char kAccessPointPassword[] = "ASCE321#";
+constexpr uint8_t kEspNowChannel = 6;
+constexpr std::size_t kMotorCount = 4;
+constexpr uint32_t kControlTimeoutMs = 500;
+
+struct MotorPinConfig {
+  uint8_t forwardPin;
+  uint8_t reversePin;
+  uint8_t forwardChannel;
+  uint8_t reverseChannel;
+  bool inverted;
+};
+
+constexpr MotorPinConfig kMotorPins[kMotorCount] = {
+    {4, 5, 0, 1, false},   // Motor A
+    {6, 7, 2, 3, false},   // Motor B
+    {8, 9, 4, 5, false},   // Motor C
+    {10, 11, 6, 7, false}, // Motor D
+};
+
+constexpr uint8_t kBuzzerPin = 47;
+constexpr uint8_t kBuzzerChannel = 14;
+constexpr uint8_t kBuzzerResolutionBits = 12;
+
+constexpr uint8_t kPwmResolutionBits = 8;
+constexpr uint16_t kPwmMaxDuty = (1U << kPwmResolutionBits) - 1U;
+
+constexpr uint8_t kStatusLedPin = 48;
+
+} // namespace config

--- a/include/motor_driver.h
+++ b/include/motor_driver.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Arduino.h>
+#include <cstdint>
+
+#include "device_config.h"
+
+class MotorDriver {
+public:
+  MotorDriver() = default;
+
+  void begin(const config::MotorPinConfig &config);
+  void applyCommand(float command, bool brake);
+  void stop();
+
+private:
+  static uint32_t selectFrequency(float magnitude);
+  void writeDuty(uint16_t forwardDuty, uint16_t reverseDuty);
+
+  config::MotorPinConfig config_{};
+  uint32_t currentFrequency_ = 4000;
+};
+

--- a/include/network_setup.h
+++ b/include/network_setup.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <ArduinoOTA.h>
+#include <esp_now.h>
+
+#include <functional>
+
+void ConfigureWiFi(const char *hostname, const char *ssid, const char *password, uint8_t channel);
+bool InitializeEspNow(esp_now_recv_cb_t callback);
+void ConfigureOta(const char *hostname, const char *password, const char *ssid,
+                  const std::function<void()> &onStart,
+                  const std::function<void()> &onEnd,
+                  const std::function<void(unsigned int, unsigned int)> &onProgress,
+                  const std::function<void(ota_error_t)> &onError);
+void HandleOtaLoop();
+

--- a/include/status_led.h
+++ b/include/status_led.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Adafruit_NeoPixel.h>
+#include <cstdint>
+
+class StatusLed {
+public:
+  enum class Mode {
+    kBoot,
+    kPairing,
+    kConnected,
+    kFailsafe,
+  };
+
+  StatusLed();
+
+  void begin(uint8_t pin);
+  void setMode(Mode mode);
+  void setDriveBalance(float leftIntensity, float rightIntensity);
+  void update();
+
+private:
+  void showColor(uint8_t red, uint8_t green, uint8_t blue);
+
+  Adafruit_NeoPixel pixel_;
+  Mode mode_ = Mode::kBoot;
+  uint32_t modeChangeMs_ = 0;
+  float leftIntensity_ = 0.0f;
+  float rightIntensity_ = 0.0f;
+  uint8_t currentRed_ = 0;
+  uint8_t currentGreen_ = 0;
+  uint8_t currentBlue_ = 0;
+};
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,5 @@
 platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
+lib_deps =
+  adafruit/Adafruit NeoPixel@^1.12.3

--- a/src/buzzer_controller.cpp
+++ b/src/buzzer_controller.cpp
@@ -1,0 +1,92 @@
+#include "buzzer_controller.h"
+
+void BuzzerController::begin(uint8_t pin, uint8_t channel, uint8_t resolutionBits) {
+  pinMode(pin, OUTPUT);
+  ledcSetup(channel, 2000, resolutionBits);
+  ledcAttachPin(pin, channel);
+  channel_ = channel;
+  resolutionBits_ = resolutionBits;
+}
+
+void BuzzerController::update() {
+  const uint32_t now = millis();
+  if (!playing_ || sequence_ == nullptr) {
+    return;
+  }
+
+  if (now >= nextChangeMs_) {
+    if (inPause_) {
+      inPause_ = false;
+      loadNextStep();
+    } else if (pendingPauseMs_ > 0) {
+      ledcWriteTone(channel_, 0);
+      nextChangeMs_ = now + pendingPauseMs_;
+      pendingPauseMs_ = 0;
+      inPause_ = true;
+    } else {
+      loadNextStep();
+    }
+  }
+}
+
+void BuzzerController::playSequence(const ToneStep *sequence, std::size_t length, bool loop) {
+  sequence_ = sequence;
+  length_ = length;
+  looping_ = loop;
+  currentIndex_ = 0;
+  playing_ = true;
+  inPause_ = false;
+  pendingPauseMs_ = 0;
+  nextChangeMs_ = millis();
+  loadNextStep();
+}
+
+void BuzzerController::stop() {
+  if (!playing_) {
+    return;
+  }
+  ledcWriteTone(channel_, 0);
+  playing_ = false;
+  sequence_ = nullptr;
+  currentIndex_ = 0;
+  pendingPauseMs_ = 0;
+  inPause_ = false;
+}
+
+bool BuzzerController::isPlaying() const { return playing_; }
+
+void BuzzerController::loadNextStep() {
+  if (sequence_ == nullptr || length_ == 0) {
+    stop();
+    return;
+  }
+
+  if (currentIndex_ >= length_) {
+    if (looping_) {
+      currentIndex_ = 0;
+    } else {
+      stop();
+      return;
+    }
+  }
+
+  const ToneStep &step = sequence_[currentIndex_++];
+  if (step.frequencyHz == 0) {
+    ledcWriteTone(channel_, 0);
+  } else {
+    ledcWriteTone(channel_, step.frequencyHz);
+  }
+  nextChangeMs_ = millis() + step.durationMs;
+
+  if (step.pauseMs > 0) {
+    pendingPauseMs_ = step.pauseMs;
+    if (step.durationMs == 0) {
+      ledcWriteTone(channel_, 0);
+      nextChangeMs_ = millis() + pendingPauseMs_;
+      pendingPauseMs_ = 0;
+    }
+  } else {
+    pendingPauseMs_ = 0;
+  }
+}
+

--- a/src/control_system.cpp
+++ b/src/control_system.cpp
@@ -1,0 +1,295 @@
+#include "control_system.h"
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <esp_now.h>
+#include <math.h>
+#include <string.h>
+
+#include "network_setup.h"
+
+namespace {
+constexpr ToneStep kBootSequence[] = {
+    {784, 200, 30},  // G5
+    {988, 160, 30},  // B5
+    {1568, 180, 0},  // G6
+};
+
+constexpr ToneStep kPairingSequence[] = {
+    {1319, 120, 20}, // E6
+    {1760, 120, 0},  // A6
+};
+
+constexpr ToneStep kConnectedSequence[] = {
+    {880, 120, 10}, // A5
+    {1175, 200, 0}, // D6
+};
+
+constexpr ToneStep kHonkSequence[] = {
+    {392, 300, 20}, // G4
+    {311, 300, 0},  // D#4
+};
+
+constexpr ToneStep kFailsafeSequence[] = {
+    {220, 180, 20}, // A3
+    {0, 120, 0},
+    {220, 180, 0},
+};
+} // namespace
+
+ControlSystem *ControlSystem::instance_ = nullptr;
+
+void ControlSystem::begin() {
+  instance_ = this;
+
+  statusLed_.begin(config::kStatusLedPin);
+  statusLed_.setMode(StatusLed::Mode::kBoot);
+
+  for (std::size_t i = 0; i < config::kMotorCount; ++i) {
+    motors_[i].begin(config::kMotorPins[i]);
+    lastMotorCommands_[i] = 0.0f;
+  }
+
+  buzzer_.begin(config::kBuzzerPin, config::kBuzzerChannel, config::kBuzzerResolutionBits);
+  buzzer_.playSequence(kBootSequence, ToneSequenceLength(kBootSequence));
+
+  ConfigureWiFi(config::kDeviceIdentity, config::kAccessPointSsid, config::kAccessPointPassword,
+                config::kEspNowChannel);
+  if (!InitializeEspNow(&ControlSystem::EspNowReceiveTrampoline)) {
+    Serial.println("ESP-NOW callback registration failed");
+  }
+
+  ConfigureOta(
+      config::kDeviceIdentity, config::kAccessPointPassword, config::kAccessPointSsid,
+      []() { Serial.println("OTA update started"); },
+      [this]() {
+        Serial.println("OTA update finished");
+        buzzer_.playSequence(kPairingSequence, ToneSequenceLength(kPairingSequence));
+      },
+      [](unsigned int progress, unsigned int total) {
+        Serial.printf("OTA progress: %u%%\n", (progress * 100U) / total);
+      },
+      [](ota_error_t error) { Serial.printf("OTA Error[%u]\n", error); });
+
+  pendingPairingTone_ = true;
+  updateStatusForPairing();
+  failsafeActive_ = false;
+  pairingState_ = PairingState{};
+  lastControlTimestamp_ = 0;
+}
+
+void ControlSystem::loop() {
+  buzzer_.update();
+  statusLed_.update();
+
+  if (pendingPairingTone_ && !buzzer_.isPlaying()) {
+    buzzer_.playSequence(kPairingSequence, ToneSequenceLength(kPairingSequence));
+    pendingPairingTone_ = false;
+  }
+
+  HandleOtaLoop();
+
+  const uint32_t now = millis();
+  if (pairingState_.paired && (now - lastControlTimestamp_ > config::kControlTimeoutMs)) {
+    enterFailsafe();
+  }
+}
+
+void ControlSystem::onEspNowData(const uint8_t *mac, const uint8_t *data, int len) {
+  bool handled = false;
+
+  if (len == static_cast<int>(sizeof(protocol::IdentityMessage))) {
+    const auto &message = *reinterpret_cast<const protocol::IdentityMessage *>(data);
+    const protocol::MessageType type = static_cast<protocol::MessageType>(message.type);
+    switch (type) {
+    case protocol::MessageType::kScanRequest:
+      handleScanRequest(mac);
+      handled = true;
+      break;
+    case protocol::MessageType::kControllerIdentity:
+      handleControllerIdentity(mac, message);
+      handled = true;
+      break;
+    case protocol::MessageType::kDroneIdentity:
+    case protocol::MessageType::kDroneAck:
+      handled = true;
+      break;
+    default:
+      break;
+    }
+  }
+
+  if (!handled && len >= static_cast<int>(sizeof(protocol::ControlMessage))) {
+    const auto &packet = *reinterpret_cast<const protocol::ControlMessage *>(data);
+    if (packet.type == static_cast<uint8_t>(protocol::MessageType::kControlCommand)) {
+      handleControlPacket(mac, packet);
+    }
+  }
+}
+
+void ControlSystem::EspNowReceiveTrampoline(const uint8_t *mac, const uint8_t *data, int len) {
+  if (instance_ != nullptr) {
+    instance_->onEspNowData(mac, data, len);
+  }
+}
+
+void ControlSystem::handleScanRequest(const uint8_t *mac) {
+  Serial.printf("Discovery scan from %02X:%02X:%02X:%02X:%02X:%02X\n", mac[0], mac[1], mac[2], mac[3], mac[4],
+                mac[5]);
+  sendIdentityMessage(mac, protocol::MessageType::kDroneIdentity);
+}
+
+void ControlSystem::handleControllerIdentity(const uint8_t *mac,
+                                             const protocol::IdentityMessage &message) {
+  const bool sameController = pairingState_.paired && memcmp(mac, pairingState_.controllerMac, 6) == 0;
+
+  if (!sameController) {
+    memcpy(pairingState_.controllerMac, mac, 6);
+    strlcpy(pairingState_.controllerName, message.identity, sizeof(pairingState_.controllerName));
+    pairingState_.paired = true;
+    lastControlTimestamp_ = millis();
+    pendingPairingTone_ = false;
+    exitFailsafe();
+    stopAllMotors();
+    Serial.printf("Paired with controller %s (%02X:%02X:%02X:%02X:%02X:%02X)\n", pairingState_.controllerName,
+                  mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    buzzer_.playSequence(kConnectedSequence, ToneSequenceLength(kConnectedSequence));
+    updateStatusForConnection();
+  } else {
+    if (strncmp(pairingState_.controllerName, message.identity, sizeof(pairingState_.controllerName)) != 0) {
+      strlcpy(pairingState_.controllerName, message.identity, sizeof(pairingState_.controllerName));
+    }
+    lastControlTimestamp_ = millis();
+  }
+
+  sendIdentityMessage(mac, protocol::MessageType::kDroneAck);
+}
+
+void ControlSystem::handleControlPacket(const uint8_t *mac, const protocol::ControlMessage &packet) {
+  if (packet.version != protocol::kControlProtocolVersion) {
+    Serial.printf("Ignoring control packet with incompatible version: %u\n", packet.version);
+    return;
+  }
+
+  if (!pairingState_.paired || memcmp(mac, pairingState_.controllerMac, 6) != 0) {
+    Serial.println("Ignoring control packet from unpaired controller");
+    return;
+  }
+
+  lastControlTimestamp_ = millis();
+  exitFailsafe();
+
+  const std::size_t motorsPerSide = config::kMotorCount / 2;
+  float leftSum = 0.0f;
+  float rightSum = 0.0f;
+
+  for (std::size_t i = 0; i < config::kMotorCount; ++i) {
+    const float command = static_cast<float>(packet.motorDuty[i]) / 1000.0f;
+    const bool brake = (packet.flags & protocol::BrakeFlagForMotor(i)) != 0;
+    motors_[i].applyCommand(command, brake);
+    lastMotorCommands_[i] = command;
+
+    const float magnitude = brake ? 0.0f : fabsf(command);
+    if (i < motorsPerSide) {
+      leftSum += magnitude;
+    } else {
+      rightSum += magnitude;
+    }
+  }
+
+  const float leftAvg = leftSum / static_cast<float>(motorsPerSide);
+  const float rightAvg = rightSum / static_cast<float>(motorsPerSide);
+  statusLed_.setDriveBalance(leftAvg, rightAvg);
+  updateStatusForConnection();
+
+  if (packet.flags & protocol::kControlFlagHonk) {
+    buzzer_.playSequence(kHonkSequence, ToneSequenceLength(kHonkSequence));
+  }
+}
+
+void ControlSystem::ensurePeer(const uint8_t *mac) {
+  if (esp_now_is_peer_exist(mac)) {
+    return;
+  }
+
+  esp_now_peer_info_t peerInfo{};
+  memcpy(peerInfo.peer_addr, mac, 6);
+  peerInfo.channel = 0;
+  peerInfo.encrypt = false;
+  peerInfo.ifidx = WIFI_IF_STA;
+  if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+    Serial.println("Failed to add ESP-NOW peer");
+  }
+}
+
+void ControlSystem::sendIdentityMessage(const uint8_t *mac, protocol::MessageType type) {
+  protocol::IdentityMessage message{};
+  message.type = static_cast<uint8_t>(type);
+  strlcpy(message.identity, config::kDeviceIdentity, sizeof(message.identity));
+  WiFi.macAddress(message.mac);
+  ensurePeer(mac);
+  if (esp_now_send(mac, reinterpret_cast<uint8_t *>(&message), sizeof(message)) != ESP_OK) {
+    Serial.println("Failed to send identity message");
+  }
+}
+
+void ControlSystem::stopAllMotors() {
+  for (std::size_t i = 0; i < config::kMotorCount; ++i) {
+    motors_[i].stop();
+    lastMotorCommands_[i] = 0.0f;
+  }
+  statusLed_.setDriveBalance(0.0f, 0.0f);
+}
+
+void ControlSystem::enterFailsafe() {
+  if (failsafeActive_) {
+    return;
+  }
+  stopAllMotors();
+  buzzer_.playSequence(kFailsafeSequence, ToneSequenceLength(kFailsafeSequence));
+  failsafeActive_ = true;
+  statusLed_.setMode(StatusLed::Mode::kFailsafe);
+}
+
+void ControlSystem::exitFailsafe() {
+  if (!failsafeActive_) {
+    return;
+  }
+  failsafeActive_ = false;
+  buzzer_.stop();
+  if (pairingState_.paired) {
+    updateStatusForConnection();
+  } else {
+    updateStatusForPairing();
+  }
+}
+
+void ControlSystem::updateDriveIndicator() {
+  const std::size_t motorsPerSide = config::kMotorCount / 2;
+  float leftSum = 0.0f;
+  float rightSum = 0.0f;
+
+  for (std::size_t i = 0; i < config::kMotorCount; ++i) {
+    const float magnitude = fabsf(lastMotorCommands_[i]);
+    if (i < motorsPerSide) {
+      leftSum += magnitude;
+    } else {
+      rightSum += magnitude;
+    }
+  }
+
+  const float leftAvg = leftSum / static_cast<float>(motorsPerSide);
+  const float rightAvg = rightSum / static_cast<float>(motorsPerSide);
+  statusLed_.setDriveBalance(leftAvg, rightAvg);
+}
+
+void ControlSystem::updateStatusForPairing() {
+  statusLed_.setMode(StatusLed::Mode::kPairing);
+  statusLed_.setDriveBalance(0.0f, 0.0f);
+}
+
+void ControlSystem::updateStatusForConnection() {
+  statusLed_.setMode(StatusLed::Mode::kConnected);
+  updateDriveIndicator();
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,18 +1,17 @@
 #include <Arduino.h>
 
-// put function declarations here:
-int myFunction(int, int);
+#include "control_system.h"
+
+ControlSystem g_controlSystem;
 
 void setup() {
-  // put your setup code here, to run once:
-  int result = myFunction(2, 3);
+  Serial.begin(115200);
+  delay(200);
+  Serial.println();
+  Serial.println("=== Thegiller-PT12 Boot ===");
+
+  g_controlSystem.begin();
 }
 
-void loop() {
-  // put your main code here, to run repeatedly:
-}
+void loop() { g_controlSystem.loop(); }
 
-// put function definitions here:
-int myFunction(int x, int y) {
-  return x + y;
-}

--- a/src/motor_driver.cpp
+++ b/src/motor_driver.cpp
@@ -1,0 +1,67 @@
+#include "motor_driver.h"
+
+#include <math.h>
+
+void MotorDriver::begin(const config::MotorPinConfig &config) {
+  config_ = config;
+  pinMode(config_.forwardPin, OUTPUT);
+  pinMode(config_.reversePin, OUTPUT);
+
+  ledcSetup(config_.forwardChannel, 4000, config::kPwmResolutionBits);
+  ledcSetup(config_.reverseChannel, 4000, config::kPwmResolutionBits);
+  ledcAttachPin(config_.forwardPin, config_.forwardChannel);
+  ledcAttachPin(config_.reversePin, config_.reverseChannel);
+  writeDuty(0, 0);
+  currentFrequency_ = 4000;
+}
+
+void MotorDriver::applyCommand(float command, bool brake) {
+  if (brake) {
+    writeDuty(config::kPwmMaxDuty, config::kPwmMaxDuty);
+    return;
+  }
+
+  float constrained = constrain(command, -1.0f, 1.0f);
+  if (config_.inverted) {
+    constrained = -constrained;
+  }
+
+  const float magnitude = fabsf(constrained);
+  const uint32_t frequency = selectFrequency(magnitude);
+  if (frequency != currentFrequency_) {
+    ledcChangeFrequency(config_.forwardChannel, frequency, config::kPwmResolutionBits);
+    ledcChangeFrequency(config_.reverseChannel, frequency, config::kPwmResolutionBits);
+    currentFrequency_ = frequency;
+  }
+
+  const uint16_t dutyValue = static_cast<uint16_t>(roundf(magnitude * config::kPwmMaxDuty));
+
+  if (constrained > 0.01f) {
+    writeDuty(dutyValue, 0);
+  } else if (constrained < -0.01f) {
+    writeDuty(0, dutyValue);
+  } else {
+    writeDuty(0, 0);
+  }
+}
+
+void MotorDriver::stop() { writeDuty(0, 0); }
+
+uint32_t MotorDriver::selectFrequency(float magnitude) {
+  if (magnitude < 0.05f) {
+    return 400;
+  }
+  if (magnitude < 0.2f) {
+    return 800;
+  }
+  if (magnitude < 0.5f) {
+    return 2000;
+  }
+  return 4000;
+}
+
+void MotorDriver::writeDuty(uint16_t forwardDuty, uint16_t reverseDuty) {
+  ledcWrite(config_.forwardChannel, forwardDuty);
+  ledcWrite(config_.reverseChannel, reverseDuty);
+}
+

--- a/src/network_setup.cpp
+++ b/src/network_setup.cpp
@@ -1,0 +1,53 @@
+#include "network_setup.h"
+
+#include <Arduino.h>
+#include <WiFi.h>
+
+void ConfigureWiFi(const char *hostname, const char *ssid, const char *password, uint8_t channel) {
+  WiFi.mode(WIFI_AP_STA);
+  WiFi.setSleep(false);
+  WiFi.setHostname(hostname);
+  bool apResult = WiFi.softAP(ssid, password, channel);
+  if (!apResult) {
+    Serial.println("Failed to start access point");
+  } else {
+    Serial.printf("Access point \"%s\" started on channel %u\n", ssid, channel);
+  }
+}
+
+bool InitializeEspNow(esp_now_recv_cb_t callback) {
+  if (esp_now_init() != ESP_OK) {
+    Serial.println("ESP-NOW init failed");
+    return false;
+  }
+  esp_now_register_recv_cb(callback);
+  Serial.println("ESP-NOW ready for ILITE pairing");
+  return true;
+}
+
+void ConfigureOta(const char *hostname, const char *password, const char *ssid,
+                  const std::function<void()> &onStart, const std::function<void()> &onEnd,
+                  const std::function<void(unsigned int, unsigned int)> &onProgress,
+                  const std::function<void(ota_error_t)> &onError) {
+  ArduinoOTA.setHostname(hostname);
+  ArduinoOTA.setPassword(password);
+
+  if (onStart) {
+    ArduinoOTA.onStart(onStart);
+  }
+  if (onEnd) {
+    ArduinoOTA.onEnd(onEnd);
+  }
+  if (onProgress) {
+    ArduinoOTA.onProgress(onProgress);
+  }
+  if (onError) {
+    ArduinoOTA.onError(onError);
+  }
+
+  ArduinoOTA.begin();
+  Serial.printf("OTA ready on AP %s\n", ssid);
+}
+
+void HandleOtaLoop() { ArduinoOTA.handle(); }
+

--- a/src/status_led.cpp
+++ b/src/status_led.cpp
@@ -1,0 +1,71 @@
+#include "status_led.h"
+
+#include <Arduino.h>
+#include <math.h>
+
+StatusLed::StatusLed() : pixel_(1, -1, NEO_GRB + NEO_KHZ800) {}
+
+void StatusLed::begin(uint8_t pin) {
+  pixel_.setPin(pin);
+  pixel_.begin();
+  pixel_.show();
+  modeChangeMs_ = millis();
+}
+
+void StatusLed::setMode(Mode mode) {
+  if (mode_ == mode) {
+    return;
+  }
+  mode_ = mode;
+  modeChangeMs_ = millis();
+}
+
+void StatusLed::setDriveBalance(float leftIntensity, float rightIntensity) {
+  leftIntensity_ = constrain(leftIntensity, 0.0f, 1.0f);
+  rightIntensity_ = constrain(rightIntensity, 0.0f, 1.0f);
+}
+
+void StatusLed::update() {
+  const uint32_t now = millis();
+  switch (mode_) {
+  case Mode::kBoot: {
+    float phase = fmodf(static_cast<float>(now - modeChangeMs_), 2000.0f) / 2000.0f;
+    float brightness = 0.3f + 0.7f * (0.5f - 0.5f * cosf(phase * 2.0f * PI));
+    showColor(0, 0, static_cast<uint8_t>(brightness * 255.0f));
+    break;
+  }
+  case Mode::kPairing: {
+    float phase = fmodf(static_cast<float>(now - modeChangeMs_), 1500.0f) / 1500.0f;
+    float brightness = 0.2f + 0.8f * fabsf(sinf(phase * PI));
+    showColor(static_cast<uint8_t>(brightness * 40.0f), static_cast<uint8_t>(brightness * 200.0f),
+              static_cast<uint8_t>(brightness * 120.0f));
+    break;
+  }
+  case Mode::kConnected: {
+    const float left = leftIntensity_;
+    const float right = rightIntensity_;
+    const uint8_t red = static_cast<uint8_t>(constrain(right, 0.0f, 1.0f) * 255.0f);
+    const uint8_t green = static_cast<uint8_t>(constrain(left, 0.0f, 1.0f) * 255.0f);
+    const uint8_t blue = (left < 0.05f && right < 0.05f) ? 30 : 0;
+    showColor(red, green, blue);
+    break;
+  }
+  case Mode::kFailsafe: {
+    bool on = ((now - modeChangeMs_) / 200) % 2 == 0;
+    showColor(on ? 255 : 0, 0, 0);
+    break;
+  }
+  }
+}
+
+void StatusLed::showColor(uint8_t red, uint8_t green, uint8_t blue) {
+  if (currentRed_ == red && currentGreen_ == green && currentBlue_ == blue) {
+    return;
+  }
+  currentRed_ = red;
+  currentGreen_ = green;
+  currentBlue_ = blue;
+  pixel_.setPixelColor(0, pixel_.Color(red, green, blue));
+  pixel_.show();
+}
+


### PR DESCRIPTION
## Summary
- factor hardware, network, and protocol logic into dedicated headers/sources and simplify the Arduino entry point
- extend the ILITE control protocol with per-motor brake flags, implement BTS7960 braking behaviour, and retain adaptive PWM selection
- drive the ESP32-S3 NeoPixel LED for boot/pairing/failsafe cues plus left/right motor dominance blending while reusing buzzer cues

## Testing
- `pio run` *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_68cc36fbe2ac832a8ee51e1ddfe52907