### PR TITLE
Implement motor driver PWM configuration

### DIFF
--- a/include/device_config.h
+++ b/include/device_config.h
@@ -20,11 +20,21 @@ struct MotorPinConfig {
   bool inverted;
 };
 
+constexpr float kMotorCommandDeadband = 0.01f;
+constexpr float kMotorFrequencyThresholdLow = 0.05f;
+constexpr float kMotorFrequencyThresholdMidLow = 0.2f;
+constexpr float kMotorFrequencyThresholdMidHigh = 0.5f;
+constexpr uint32_t kMotorPwmFrequencyLow = 400;
+constexpr uint32_t kMotorPwmFrequencyMidLow = 800;
+constexpr uint32_t kMotorPwmFrequencyMidHigh = 2000;
+constexpr uint32_t kMotorPwmFrequencyHigh = 4000;
+
 constexpr MotorPinConfig kMotorPins[kMotorCount] = {
-    {4, 5, 0, 1, false},   // Motor A
-    {6, 7, 2, 3, false},   // Motor B
-    {8, 9, 4, 5, false},   // Motor C
-    {10, 11, 6, 7, false}, // Motor D
+    // Left side motors share orientation, right side are mirrored and inverted.
+    {16, 15, 0, 1, false},  // Front left motor (H-bridge A1/A2)
+    {18, 17, 2, 3, false},  // Rear left motor (H-bridge B1/B2)
+    {13, 14, 4, 5, true},   // Front right motor (H-bridge C1/C2)
+    {11, 12, 6, 7, true},   // Rear right motor (H-bridge D1/D2)
 };
 
 constexpr uint8_t kBuzzerPin = 47;

--- a/include/motor_driver.h
+++ b/include/motor_driver.h
@@ -18,6 +18,6 @@ private:
   void writeDuty(uint16_t forwardDuty, uint16_t reverseDuty);
 
   config::MotorPinConfig config_{};
-  uint32_t currentFrequency_ = 4000;
+  uint32_t currentFrequency_ = config::kMotorPwmFrequencyHigh;
 };
 


### PR DESCRIPTION
## Summary
- configure dedicated constants for the motor PWM frequency tiers and command deadband
- assign each motor to its GPIO pins and LEDC channels, including mirrored inversion on the right side
- update the motor driver to consume the shared configuration values instead of hard-coded numbers

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc44117618832ab1c9b1a1b7021deb