### PR TITLE
Add ILITE command compatibility

### DIFF
--- a/include/control_protocol.h
+++ b/include/control_protocol.h
@@ -29,14 +29,32 @@ struct ControlMessage {
   int16_t motorDuty[config::kMotorCount];
   uint16_t flags;
 };
+
+struct GillControlPacket {
+  uint32_t magic;
+  int16_t leftFront;
+  int16_t leftRear;
+  int16_t rightFront;
+  int16_t rightRear;
+  float easingRate;
+  uint8_t mode;
+  uint8_t easing;
+  uint8_t flags;
+  uint8_t reserved;
+};
 #pragma pack(pop)
 
 static_assert(sizeof(IdentityMessage) == 23, "IdentityMessage must match ILITE discovery payload size");
 static_assert(sizeof(ControlMessage) == 16, "ControlMessage layout must stay byte-packed for ESP-NOW");
+static_assert(sizeof(GillControlPacket) == 20, "GillControlPacket layout must match ILITE controller output");
 
 constexpr uint8_t kControlProtocolVersion = 1;
 constexpr uint16_t kControlFlagHonk = 0x0001;
 constexpr uint16_t kControlFlagBrakeBase = 0x0010;
+
+constexpr uint32_t kGillPacketMagic = 0x54474C4C; // 'TGLL'
+constexpr uint8_t kGillFlagBrake = 0x01;
+constexpr uint8_t kGillFlagHonk = 0x02;
 
 inline constexpr uint16_t BrakeFlagForMotor(std::size_t index) {
   return static_cast<uint16_t>(kControlFlagBrakeBase << index);

--- a/include/control_system.h
+++ b/include/control_system.h
@@ -26,6 +26,7 @@ private:
   void handleScanRequest(const uint8_t *mac);
   void handleControllerIdentity(const uint8_t *mac, const protocol::IdentityMessage &message);
   void handleControlPacket(const uint8_t *mac, const protocol::ControlMessage &packet);
+  void handleGillControlPacket(const uint8_t *mac, const protocol::GillControlPacket &packet);
   void ensurePeer(const uint8_t *mac);
   void sendIdentityMessage(const uint8_t *mac, protocol::MessageType type);
   void stopAllMotors();

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -8,7 +8,7 @@ namespace config {
 constexpr const char kDeviceIdentity[] = "Thegiller-PT12";
 constexpr const char kAccessPointSsid[] = "Thegill PORT";
 constexpr const char kAccessPointPassword[] = "ASCE321#";
-constexpr uint8_t kEspNowChannel = 6;
+constexpr uint8_t kEspNowChannel = 1;
 constexpr std::size_t kMotorCount = 4;
 constexpr uint32_t kControlTimeoutMs = 500;
 


### PR DESCRIPTION
## Summary
- add the ILITE Thegill command packet definition so incoming controller data can be recognised
- handle the new packet in the control system, mapping brake/honk flags to the onboard hardware
- align the ESP-NOW channel with the ILITE controller default to restore pairing

## Testing
- pio run *(fails: PlatformIO could not download dependencies and returned HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68cc50f2076c832a9e7d6ce835952ee9