### PR TITLE
Implement Dronegaze-style pairing handshake

### DIFF
--- a/include/control_system.h
+++ b/include/control_system.h
@@ -28,7 +28,7 @@ private:
   void handleControlPacket(const uint8_t *mac, const protocol::ControlMessage &packet);
   void handleGillControlPacket(const uint8_t *mac, const protocol::GillControlPacket &packet);
   void ensurePeer(const uint8_t *mac);
-  void sendIdentityMessage(const uint8_t *mac, protocol::MessageType type);
+  bool sendIdentityMessage(const uint8_t *mac, protocol::MessageType type);
   void stopAllMotors();
   void enterFailsafe();
   void exitFailsafe();
@@ -40,7 +40,9 @@ private:
   BuzzerController buzzer_;
   StatusLed statusLed_;
   PairingState pairingState_;
+  uint8_t selfMac_[6] = {0};
   uint32_t lastControlTimestamp_ = 0;
+  uint32_t lastHandshakeTimestamp_ = 0;
   bool failsafeActive_ = false;
   bool pendingPairingTone_ = false;
   float lastMotorCommands_[config::kMotorCount] = {0};


### PR DESCRIPTION
## Summary
- cache the drone's MAC address and last handshake timestamp so Thegill can mirror Dronegaze's pairing flow
- throttle scan responses and align controller identity handling with Dronegaze, including peer setup and fallback logging
- reuse the cached MAC when sending identity messages and surface send failures to callers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc54c1265c832abd8e69145c54bb22