### PR TITLE
Add buzzer boot sequence helper

### DIFF
--- a/include/buzzer_controller.h
+++ b/include/buzzer_controller.h
@@ -20,6 +20,7 @@ public:
   void begin(uint8_t pin, uint8_t channel, uint8_t resolutionBits);
   void update();
   void playSequence(const ToneStep *sequence, std::size_t length, bool loop = false);
+  void playBootSequence(bool loop = false);
   void stop();
   bool isPlaying() const;
 

--- a/src/buzzer_controller.cpp
+++ b/src/buzzer_controller.cpp
@@ -1,5 +1,13 @@
 #include "buzzer_controller.h"
 
+namespace {
+constexpr ToneStep kDefaultBootSequence[] = {
+    {784, 200, 30},  // G5
+    {988, 160, 30},  // B5
+    {1568, 180, 0},  // G6
+};
+} // namespace
+
 void BuzzerController::begin(uint8_t pin, uint8_t channel, uint8_t resolutionBits) {
   pinMode(pin, OUTPUT);
   ledcSetup(channel, 2000, resolutionBits);
@@ -57,6 +65,10 @@ void BuzzerController::stop() {
 }
 
 bool BuzzerController::isPlaying() const { return playing_; }
+
+void BuzzerController::playBootSequence(bool loop) {
+  playSequence(kDefaultBootSequence, ToneSequenceLength(kDefaultBootSequence), loop);
+}
 
 void BuzzerController::loadNextStep() {
   if (sequence_ == nullptr || length_ == 0) {

--- a/src/control_system.cpp
+++ b/src/control_system.cpp
@@ -9,12 +9,6 @@
 #include "network_setup.h"
 
 namespace {
-constexpr ToneStep kBootSequence[] = {
-    {784, 200, 30},  // G5
-    {988, 160, 30},  // B5
-    {1568, 180, 0},  // G6
-};
-
 constexpr ToneStep kPairingSequence[] = {
     {1319, 120, 20}, // E6
     {1760, 120, 0},  // A6
@@ -53,7 +47,7 @@ void ControlSystem::begin() {
   }
 
   buzzer_.begin(config::kBuzzerPin, config::kBuzzerChannel, config::kBuzzerResolutionBits);
-  buzzer_.playSequence(kBootSequence, ToneSequenceLength(kBootSequence));
+  buzzer_.playBootSequence();
 
   ConfigureWiFi(config::kDeviceIdentity, config::kAccessPointSsid, config::kAccessPointPassword,
                 config::kEspNowChannel);


### PR DESCRIPTION
## Summary
- add a built-in boot tone sequence to the buzzer controller
- expose a helper for the boot tone and use it when the control system starts up

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5cd0c2f0832abf6e3326b81d0f95