### PR TITLE
Implement software-driven buzzer and sync ESP-NOW channel

### DIFF
--- a/include/control_system.h
+++ b/include/control_system.h
@@ -1,6 +1,13 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
+
+#include <esp_now.h>
 
 #include "buzzer_controller.h"
 #include "control_protocol.h"
@@ -15,6 +22,12 @@ public:
   void onEspNowData(const uint8_t *mac, const uint8_t *data, int len);
 
 private:
+  struct EspNowPacket {
+    uint8_t mac[6];
+    uint16_t length;
+    uint8_t payload[ESP_NOW_MAX_DATA_LEN];
+  };
+
   struct PairingState {
     bool paired = false;
     uint8_t controllerMac[6] = {0};
@@ -22,7 +35,12 @@ private:
   };
 
   static void EspNowReceiveTrampoline(const uint8_t *mac, const uint8_t *data, int len);
+  static void EspNowTaskTrampoline(void *param);
+  static void UpdateTaskTrampoline(void *param);
 
+  void enqueueEspNowPacketFromIsr(const uint8_t *mac, const uint8_t *data, int len);
+  void espNowTask();
+  void updateTask();
   void handleScanRequest(const uint8_t *mac);
   void handleControllerIdentity(const uint8_t *mac, const protocol::IdentityMessage &message);
   void handleControlPacket(const uint8_t *mac, const protocol::ControlMessage &packet);
@@ -46,6 +64,11 @@ private:
   bool failsafeActive_ = false;
   bool pendingPairingTone_ = false;
   float lastMotorCommands_[config::kMotorCount] = {0};
+
+  QueueHandle_t espNowQueue_ = nullptr;
+  TaskHandle_t espNowTaskHandle_ = nullptr;
+  TaskHandle_t updateTaskHandle_ = nullptr;
+  std::atomic<uint32_t> droppedPacketCount_{0};
 
   static ControlSystem *instance_;
 };

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -8,7 +8,7 @@ namespace config {
 constexpr const char kDeviceIdentity[] = "Thegiller-PT12";
 constexpr const char kAccessPointSsid[] = "Thegill PORT";
 constexpr const char kAccessPointPassword[] = "ASCE321#";
-constexpr uint8_t kEspNowChannel = 1;
+constexpr uint8_t kEspNowChannel = 6;
 constexpr std::size_t kMotorCount = 4;
 constexpr uint32_t kControlTimeoutMs = 500;
 
@@ -38,8 +38,6 @@ constexpr MotorPinConfig kMotorPins[kMotorCount] = {
 };
 
 constexpr uint8_t kBuzzerPin = 47;
-constexpr uint8_t kBuzzerChannel = 14;
-constexpr uint8_t kBuzzerResolutionBits = 12;
 
 constexpr uint8_t kPwmResolutionBits = 8;
 constexpr uint16_t kPwmMaxDuty = (1U << kPwmResolutionBits) - 1U;

--- a/src/buzzer_controller.cpp
+++ b/src/buzzer_controller.cpp
@@ -8,13 +8,24 @@ constexpr ToneStep kDefaultBootSequence[] = {
 };
 } // namespace
 
-void BuzzerController::begin(uint8_t pin, uint8_t channel, uint8_t resolutionBits) {
-  pinMode(pin, OUTPUT);
-  ledcSetup(channel, 2000, resolutionBits);
-  ledcAttachPin(pin, channel);
-  channel_ = channel;
-  resolutionBits_ = resolutionBits;
-  ledcWrite(channel_, 0);
+void BuzzerController::begin(uint8_t pin) {
+  pinNumber_ = pin;
+  gpioPin_ = static_cast<gpio_num_t>(pin);
+  pinMode(pinNumber_, OUTPUT);
+  digitalWrite(pinNumber_, LOW);
+
+  if (toneTimer_ == nullptr) {
+    esp_timer_create_args_t args{};
+    args.callback = &BuzzerController::TimerCallback;
+    args.arg = this;
+    args.dispatch_method = ESP_TIMER_TASK;
+    args.name = "buzzer";
+
+    const esp_err_t result = esp_timer_create(&args, &toneTimer_);
+    if (result != ESP_OK) {
+      Serial.printf("Failed to create buzzer timer (err=%d)\n", static_cast<int>(result));
+    }
+  }
 }
 
 void BuzzerController::update() {
@@ -28,8 +39,7 @@ void BuzzerController::update() {
       inPause_ = false;
       loadNextStep();
     } else if (pendingPauseMs_ > 0) {
-      ledcWriteTone(channel_, 0);
-      ledcWrite(channel_, 0);
+      stopToneOutput();
       nextChangeMs_ = now + pendingPauseMs_;
       pendingPauseMs_ = 0;
       inPause_ = true;
@@ -55,8 +65,7 @@ void BuzzerController::stop() {
   if (!playing_) {
     return;
   }
-  ledcWriteTone(channel_, 0);
-  ledcWrite(channel_, 0);
+  stopToneOutput();
   playing_ = false;
   sequence_ = nullptr;
   currentIndex_ = 0;
@@ -87,26 +96,73 @@ void BuzzerController::loadNextStep() {
 
   const ToneStep &step = sequence_[currentIndex_++];
   if (step.frequencyHz == 0) {
-    ledcWriteTone(channel_, 0);
-    ledcWrite(channel_, 0);
+    stopToneOutput();
   } else {
-    ledcWriteTone(channel_, step.frequencyHz);
-    const uint32_t maxDuty = (1u << resolutionBits_) - 1u;
-    const uint32_t duty = maxDuty > 0 ? ((maxDuty + 1u) / 2u) : 0u;
-    ledcWrite(channel_, duty);
+    startTone(step.frequencyHz);
   }
   nextChangeMs_ = millis() + step.durationMs;
 
   if (step.pauseMs > 0) {
     pendingPauseMs_ = step.pauseMs;
     if (step.durationMs == 0) {
-      ledcWriteTone(channel_, 0);
-      ledcWrite(channel_, 0);
+      stopToneOutput();
       nextChangeMs_ = millis() + pendingPauseMs_;
       pendingPauseMs_ = 0;
     }
   } else {
     pendingPauseMs_ = 0;
   }
+}
+
+void BuzzerController::startTone(uint16_t frequencyHz) {
+  if (frequencyHz == 0 || toneTimer_ == nullptr || gpioPin_ == GPIO_NUM_NC) {
+    stopToneOutput();
+    return;
+  }
+
+  uint32_t periodUs = frequencyHz > 0 ? static_cast<uint32_t>(1000000UL / frequencyHz) : 0UL;
+  if (periodUs == 0) {
+    periodUs = 1;
+  }
+  const uint64_t halfPeriodUs = static_cast<uint64_t>(periodUs) / 2ULL;
+  const uint64_t intervalUs = halfPeriodUs > 0 ? halfPeriodUs : 1ULL;
+
+  esp_timer_stop(toneTimer_);
+  pinState_.store(false, std::memory_order_relaxed);
+  gpio_set_level(gpioPin_, 0);
+
+  toneActive_.store(true, std::memory_order_release);
+  if (esp_timer_start_periodic(toneTimer_, intervalUs) != ESP_OK) {
+    toneActive_.store(false, std::memory_order_release);
+    Serial.println("Failed to start buzzer timer");
+  }
+}
+
+void BuzzerController::stopToneOutput() {
+  toneActive_.store(false, std::memory_order_release);
+  if (toneTimer_ != nullptr) {
+    esp_timer_stop(toneTimer_);
+  }
+  pinState_.store(false, std::memory_order_relaxed);
+  if (gpioPin_ != GPIO_NUM_NC) {
+    gpio_set_level(gpioPin_, 0);
+  }
+}
+
+void BuzzerController::TimerCallback(void *arg) {
+  if (arg == nullptr) {
+    return;
+  }
+  static_cast<BuzzerController *>(arg)->handleTimerCallback();
+}
+
+void BuzzerController::handleTimerCallback() {
+  if (!toneActive_.load(std::memory_order_acquire) || gpioPin_ == GPIO_NUM_NC) {
+    return;
+  }
+
+  const bool newState = !pinState_.load(std::memory_order_relaxed);
+  pinState_.store(newState, std::memory_order_relaxed);
+  gpio_set_level(gpioPin_, newState ? 1 : 0);
 }
 


### PR DESCRIPTION
## Summary
- replace the LEDC-driven buzzer with an esp_timer-based software tone generator so no extra PWM channels are required
- update control system initialization to use the new buzzer interface
- match the ESP-NOW channel configuration to ILITE so pairing succeeds

## Testing
- pio run *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_68cc608b1658832a9a4c804f835eb267