### PR TITLE
Adopt Dronegaze-style ESP-NOW communications

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -8,14 +8,16 @@
 
 namespace Comms {
 
-struct DriveCommand {
-  
-  uint32_t sequence = 0;
-  uint8_t version = 0;
-  int16_t motorDuty[config::kMotorCount] = {0};
-  uint16_t flags = 0;
+constexpr uint32_t kDriveCommandMagic = 0xA1B2C3D4;
 
-};
+struct DriveCommand {
+  uint32_t magic = kDriveCommandMagic;
+  uint16_t throttle = 0;
+  int8_t pitchAngle = 0;
+  int8_t rollAngle = 0;
+  int8_t yawAngle = 0;
+  bool armMotors = false;
+} __attribute__((packed));
 
 bool init(const char *ssid, const char *password, uint8_t channel);
 bool receiveCommand(DriveCommand &cmd);

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -5,7 +5,7 @@
 
 namespace config {
 
-constexpr const char kDeviceIdentity[] = "GillerT12";
+constexpr const char kDeviceIdentity[] = "THEGILL";
 constexpr const char kAccessPointSsid[] = "Thegill PORT";
 constexpr const char kAccessPointPassword[] = "ASCE321#";
 constexpr uint8_t kEspNowChannel = 6;


### PR DESCRIPTION
## Summary
- align the ESP-NOW pairing flow with Dronegaze, advertising THEGILL and tracking the controller MAC/identity
- replace the legacy drive packet format with the Dronegaze-style packed drive command and validate by magic value
- mix throttle, yaw, pitch, and roll inputs into motor commands so the rover reacts to the new drive command layout

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8e1f0bdc832a971217bea5a99a3b