### PR TITLE
Add guard pause when retuning buzzer

### DIFF
--- a/include/buzzer_controller.h
+++ b/include/buzzer_controller.h
@@ -30,6 +30,7 @@ private:
   void loadNextStep();
   void startTone(uint16_t frequencyHz);
   void stopToneOutput();
+  bool configureToneTimer(uint32_t frequencyHz);
 
   uint8_t pinNumber_ = 0;
   bool playing_ = false;
@@ -41,5 +42,13 @@ private:
   uint32_t nextChangeMs_ = 0;
   uint16_t pendingPauseMs_ = 0;
   uint8_t channel_ = config::kBuzzerChannel;
+  bool initialized_ = false;
+  bool timerConfigured_ = false;
+  uint32_t requestedFrequencyHz_ = 0;
+  uint32_t currentFrequencyHz_ = 0;
+  uint8_t currentResolutionBits_ = config::kBuzzerResolutionBits;
+  bool pendingGuardStep_ = false;
+  ToneStep guardStep_{};
+  uint32_t guardReleaseMs_ = 0;
 };
 

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -41,6 +41,10 @@ constexpr MotorPinConfig kMotorPins[kMotorCount] = {
 constexpr uint8_t kBuzzerPin = 47;
 constexpr uint8_t kBuzzerChannel = 0;
 constexpr uint8_t kBuzzerResolutionBits = 10;
+constexpr uint8_t kBuzzerMinResolutionBits = 4;
+constexpr uint16_t kBuzzerRetuneGuardMs = 6;
+constexpr uint16_t kBuzzerRetuneGuardMinDeltaHz = 12;
+constexpr uint8_t kBuzzerRetuneGuardDeltaPercent = 6;
 
 constexpr uint8_t kPwmResolutionBits = 8;
 constexpr uint16_t kPwmMaxDuty = (1U << kPwmResolutionBits) - 1U;

--- a/src/buzzer_controller.cpp
+++ b/src/buzzer_controller.cpp
@@ -1,5 +1,9 @@
 #include "buzzer_controller.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 namespace {
 constexpr ToneStep kDefaultBootSequence[] = {
     {0, 80, 40},
@@ -19,9 +23,21 @@ constexpr ToneStep kDefaultBootSequence[] = {
 
 void BuzzerController::begin(uint8_t pin) {
   pinNumber_ = pin;
-  ledcSetup(channel_, 2000, config::kBuzzerResolutionBits);
+  pinMode(pinNumber_, OUTPUT);
+  digitalWrite(pinNumber_, LOW);
+
+  const double initialFrequency = 2000.0;
+  ledcSetup(channel_, initialFrequency, config::kBuzzerResolutionBits);
   ledcAttachPin(pinNumber_, channel_);
   ledcWrite(channel_, 0);
+
+  initialized_ = true;
+  timerConfigured_ = false;
+  requestedFrequencyHz_ = 0;
+  currentFrequencyHz_ = 0;
+  currentResolutionBits_ = config::kBuzzerResolutionBits;
+  pendingGuardStep_ = false;
+  guardReleaseMs_ = 0;
 }
 
 void BuzzerController::update() {
@@ -53,6 +69,8 @@ void BuzzerController::playSequence(const ToneStep *sequence, std::size_t length
   playing_ = true;
   inPause_ = false;
   pendingPauseMs_ = 0;
+  pendingGuardStep_ = false;
+  guardReleaseMs_ = 0;
   nextChangeMs_ = millis();
   loadNextStep();
 }
@@ -67,6 +85,8 @@ void BuzzerController::stop() {
   currentIndex_ = 0;
   pendingPauseMs_ = 0;
   inPause_ = false;
+  pendingGuardStep_ = false;
+  guardReleaseMs_ = 0;
 }
 
 bool BuzzerController::isPlaying() const { return playing_; }
@@ -90,13 +110,52 @@ void BuzzerController::loadNextStep() {
     }
   }
 
-  const ToneStep &step = sequence_[currentIndex_++];
+  if (pendingGuardStep_ && guardReleaseMs_ != 0) {
+    const uint32_t nowGuard = millis();
+    if (nowGuard < guardReleaseMs_) {
+      inPause_ = true;
+      nextChangeMs_ = guardReleaseMs_;
+      return;
+    }
+  }
+
+  ToneStep step{};
+  const uint32_t now = millis();
+  if (pendingGuardStep_) {
+    step = guardStep_;
+  } else {
+    step = sequence_[currentIndex_];
+    guardStep_ = step;
+  }
+
+  if (!pendingGuardStep_ && requestedFrequencyHz_ != 0 && step.frequencyHz != 0) {
+    const uint32_t previous = requestedFrequencyHz_;
+    const uint32_t next = step.frequencyHz;
+    const uint32_t delta = (previous > next) ? (previous - next) : (next - previous);
+    const uint32_t maxFrequency = std::max(previous, next);
+    const bool deltaLargeEnough = delta >= config::kBuzzerRetuneGuardMinDeltaHz;
+    const bool ratioLargeEnough =
+        (maxFrequency > 0) && (delta * 100U >= maxFrequency * config::kBuzzerRetuneGuardDeltaPercent);
+    if (deltaLargeEnough && ratioLargeEnough) {
+      stopToneOutput();
+      pendingGuardStep_ = true;
+      guardReleaseMs_ = now + config::kBuzzerRetuneGuardMs;
+      inPause_ = true;
+      nextChangeMs_ = guardReleaseMs_;
+      return;
+    }
+  }
+
+  pendingGuardStep_ = false;
+  guardReleaseMs_ = 0;
+  ++currentIndex_;
+
   if (step.frequencyHz == 0) {
     stopToneOutput();
   } else {
     startTone(step.frequencyHz);
   }
-  nextChangeMs_ = millis() + step.durationMs;
+  nextChangeMs_ = now + step.durationMs;
 
   if (step.pauseMs > 0) {
     pendingPauseMs_ = step.pauseMs;
@@ -111,18 +170,109 @@ void BuzzerController::loadNextStep() {
 }
 
 void BuzzerController::startTone(uint16_t frequencyHz) {
+  if (!initialized_) {
+    return;
+  }
+
   if (frequencyHz == 0) {
     stopToneOutput();
     return;
   }
 
-  ledcWriteTone(channel_, static_cast<u32_t>(frequencyHz));
-  const uint32_t duty = 1U << (config::kBuzzerResolutionBits - 1U);
-  //ledcWrite(channel_, duty);
+  if (!configureToneTimer(frequencyHz)) {
+    stopToneOutput();
+    return;
+  }
+
+  if (currentResolutionBits_ == 0) {
+    stopToneOutput();
+    return;
+  }
+
+  const uint32_t maxDuty = (1UL << currentResolutionBits_) - 1UL;
+  const uint32_t duty = (maxDuty + 1UL) / 2UL;
+  ledcWrite(channel_, duty);
 }
 
 void BuzzerController::stopToneOutput() {
-  ledcWriteTone(channel_, 0);
+  if (!initialized_) {
+    return;
+  }
   ledcWrite(channel_, 0);
+  timerConfigured_ = false;
+  requestedFrequencyHz_ = 0;
+  currentFrequencyHz_ = 0;
+}
+
+bool BuzzerController::configureToneTimer(uint32_t frequencyHz) {
+  if (!initialized_ || frequencyHz == 0) {
+    return false;
+  }
+
+  if (timerConfigured_ && requestedFrequencyHz_ == frequencyHz) {
+    return true;
+  }
+
+  const uint8_t previousResolution = currentResolutionBits_;
+  const uint32_t previousFrequency = currentFrequencyHz_;
+  const uint32_t previousRequest = requestedFrequencyHz_;
+  const bool hadPreviousConfig = timerConfigured_;
+
+  ledcWrite(channel_, 0);
+
+  const double target = static_cast<double>(frequencyHz);
+  const uint8_t maxResolution = config::kBuzzerResolutionBits;
+  const uint8_t minResolution = std::max<uint8_t>(1, config::kBuzzerMinResolutionBits);
+  constexpr double kExactMatchTolerance = 1e-6;
+
+  uint8_t bestResolution = 0;
+  uint32_t bestFrequency = 0;
+  double bestError = std::numeric_limits<double>::infinity();
+
+  for (int bits = static_cast<int>(maxResolution); bits >= static_cast<int>(minResolution); --bits) {
+    const uint32_t actual = ledcSetup(channel_, target, static_cast<uint8_t>(bits));
+    if (actual == 0) {
+      continue;
+    }
+
+    const double relativeError = std::fabs(static_cast<double>(actual) - target) / target;
+    if (relativeError < bestError) {
+      bestError = relativeError;
+      bestFrequency = actual;
+      bestResolution = static_cast<uint8_t>(bits);
+      if (relativeError <= kExactMatchTolerance) {
+        break;
+      }
+    }
+  }
+
+  if (bestResolution == 0) {
+    if (hadPreviousConfig && previousFrequency != 0) {
+      ledcSetup(channel_, static_cast<double>(previousFrequency), previousResolution);
+    }
+    timerConfigured_ = hadPreviousConfig;
+    currentResolutionBits_ = previousResolution;
+    currentFrequencyHz_ = previousFrequency;
+    requestedFrequencyHz_ = previousRequest;
+    return false;
+  }
+
+  const uint32_t applied = ledcSetup(channel_, target, bestResolution);
+  if (applied == 0) {
+    if (hadPreviousConfig && previousFrequency != 0) {
+      ledcSetup(channel_, static_cast<double>(previousFrequency), previousResolution);
+    }
+    timerConfigured_ = hadPreviousConfig;
+    currentResolutionBits_ = previousResolution;
+    currentFrequencyHz_ = previousFrequency;
+    requestedFrequencyHz_ = previousRequest;
+    return false;
+  }
+
+  currentResolutionBits_ = bestResolution;
+  currentFrequencyHz_ = applied;
+  requestedFrequencyHz_ = frequencyHz;
+  timerConfigured_ = true;
+  return true;
 }
 


### PR DESCRIPTION
## Summary
- add configurable guard timing for the buzzer so large frequency jumps insert a short pause before the next tone
- reset the buzzer guard state whenever playback starts or stops to avoid stale retune data between sequences

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8efd144c832a8a0176b960128b40