### PR TITLE
Replace motor LEDC PWM with timer-driven software PWM

### DIFF
--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -1,55 +1,155 @@
 #include "motor.h"
 #include <math.h>
+#include <driver/gpio.h>
 
 namespace Motor {
 namespace {
 struct DriverState {
     DriverPins pins;
-    uint8_t forwardChannel;
-    uint8_t reverseChannel;
-    uint8_t timer;
     bool initialised;
 };
 
+struct PwmState {
+    volatile uint32_t periodTicks;
+    volatile uint32_t onTicks;
+    volatile uint64_t cycleStart;
+    volatile uint64_t nextEvent;
+    volatile uint8_t phase;
+    volatile uint8_t activePin;
+};
+
+constexpr uint32_t PWM_MAX_FREQ = 20000;
+constexpr uint32_t PWM_MIN_FREQ = 400;
+constexpr uint32_t TIMER_BASE_FREQ = 1000000; // 1 MHz base for scheduling
+constexpr uint32_t DEFAULT_IDLE_INTERVAL = 1000; // microseconds
+
+constexpr uint8_t PHASE_START = 0;
+constexpr uint8_t PHASE_END = 1;
+constexpr uint8_t PHASE_HOLD_HIGH = 2;
+
+constexpr uint8_t ACTIVE_NONE = 0;
+constexpr uint8_t ACTIVE_FORWARD = 1;
+constexpr uint8_t ACTIVE_REVERSE = 2;
+
 static DriverState drivers[4];
+static PwmState pwmStates[4];
 static bool subsystemInitialised = false;
 static float smoothingRate = 4.0f;
 
-constexpr uint32_t LEDC_BASE_FREQ = 20000;
-constexpr uint32_t LEDC_MIN_FREQ = 400;
-constexpr uint8_t LEDC_RESOLUTION = 12; // 12-bit resolution (0-4095)
+static hw_timer_t *pwmTimer = nullptr;
+static portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
+static volatile uint64_t currentTicks = 0;
+static volatile uint32_t alarmInterval = DEFAULT_IDLE_INTERVAL;
+
+inline void IRAM_ATTR setPinLevel(int pin, int level)
+{
+    if (pin >= 0) {
+        gpio_set_level(static_cast<gpio_num_t>(pin), level ? 1 : 0);
+    }
+}
 
 uint32_t computeFrequency(float magnitude)
 {
     magnitude = constrain(magnitude, 0.0f, 1.0f);
-    return LEDC_MIN_FREQ + static_cast<uint32_t>((LEDC_BASE_FREQ - LEDC_MIN_FREQ) * magnitude);
+    return PWM_MIN_FREQ + static_cast<uint32_t>((PWM_MAX_FREQ - PWM_MIN_FREQ) * magnitude);
 }
 
-uint32_t computeDuty(float magnitude)
+uint32_t computePeriodTicks(uint32_t freq)
 {
-    magnitude = constrain(magnitude, 0.0f, 1.0f);
-    const uint32_t maxDuty = (1u << LEDC_RESOLUTION) - 1u;
-    return static_cast<uint32_t>(maxDuty * magnitude);
+    if (freq == 0) return DEFAULT_IDLE_INTERVAL;
+    uint32_t ticks = TIMER_BASE_FREQ / freq;
+    return ticks == 0 ? 1 : ticks;
 }
 
-void applyOutput(DriverState &state, int16_t command)
+inline void IRAM_ATTR setAlarmIntervalLocked(uint32_t interval)
 {
-    float magnitude = fabsf(static_cast<float>(command) / 1000.0f);
-    uint32_t freq = computeFrequency(magnitude);
-    ledcChangeFrequency(state.timer, freq, LEDC_RESOLUTION);
+    if (!pwmTimer) return;
+    if (interval == 0) interval = 1;
+    alarmInterval = interval;
+    timerWrite(pwmTimer, 0);
+    timerAlarmWrite(pwmTimer, interval, false);
+    timerAlarmEnable(pwmTimer);
+}
 
-    uint32_t duty = computeDuty(magnitude);
-    if (command >= 0) {
-        ledcWrite(state.forwardChannel, duty);
-        ledcWrite(state.reverseChannel, 0);
+void IRAM_ATTR handleDriverEvents(size_t index, uint64_t now)
+{
+    PwmState &pwm = pwmStates[index];
+    if (pwm.activePin == ACTIVE_NONE || pwm.periodTicks == 0) {
+        return;
+    }
+
+    const DriverPins &pins = drivers[index].pins;
+
+    while (pwm.nextEvent <= now) {
+        if (pwm.phase == PHASE_START) {
+            pwm.cycleStart = pwm.nextEvent;
+            setPinLevel(pins.forwardPin, LOW);
+            setPinLevel(pins.reversePin, LOW);
+
+            if (pwm.onTicks == 0) {
+                pwm.cycleStart += pwm.periodTicks;
+                pwm.nextEvent = pwm.cycleStart;
+                continue;
+            }
+
+            if (pwm.activePin == ACTIVE_FORWARD) {
+                setPinLevel(pins.forwardPin, HIGH);
+            } else {
+                setPinLevel(pins.reversePin, HIGH);
+            }
+
+            if (pwm.onTicks >= pwm.periodTicks) {
+                pwm.phase = PHASE_HOLD_HIGH;
+                pwm.nextEvent = pwm.cycleStart + pwm.periodTicks;
+            } else {
+                pwm.phase = PHASE_END;
+                pwm.nextEvent = pwm.cycleStart + pwm.onTicks;
+            }
+        } else if (pwm.phase == PHASE_END) {
+            if (pwm.activePin == ACTIVE_FORWARD) {
+                setPinLevel(pins.forwardPin, LOW);
+            } else {
+                setPinLevel(pins.reversePin, LOW);
+            }
+            pwm.phase = PHASE_START;
+            pwm.cycleStart += pwm.periodTicks;
+            pwm.nextEvent = pwm.cycleStart;
+        } else { // PHASE_HOLD_HIGH
+            pwm.phase = PHASE_START;
+            pwm.cycleStart += pwm.periodTicks;
+            pwm.nextEvent = pwm.cycleStart;
+        }
+    }
+}
+
+void IRAM_ATTR onPwmTimer()
+{
+    portENTER_CRITICAL_ISR(&timerMux);
+    uint32_t interval = alarmInterval;
+    if (interval == 0) interval = 1;
+    currentTicks += interval;
+
+    uint32_t minDelta = UINT32_MAX;
+    for (size_t i = 0; i < 4; ++i) {
+        handleDriverEvents(i, currentTicks);
+        PwmState &pwm = pwmStates[i];
+        if (pwm.activePin == ACTIVE_NONE || pwm.periodTicks == 0) continue;
+
+        if (pwm.nextEvent <= currentTicks) {
+            minDelta = 1;
+        } else {
+            uint32_t delta = static_cast<uint32_t>(pwm.nextEvent - currentTicks);
+            if (delta < minDelta) minDelta = delta;
+        }
+    }
+
+    if (minDelta == UINT32_MAX) {
+        setAlarmIntervalLocked(DEFAULT_IDLE_INTERVAL);
     } else {
-        ledcWrite(state.forwardChannel, 0);
-        ledcWrite(state.reverseChannel, duty);
+        setAlarmIntervalLocked(minDelta);
     }
 
-    if (state.pins.enablePin >= 0) {
-        digitalWrite(state.pins.enablePin, duty > 0 ? HIGH : LOW);
-    }
+    portEXIT_CRITICAL_ISR(&timerMux);
 }
 
 int16_t easeToward(int16_t current, int16_t target)
@@ -64,25 +164,81 @@ int16_t easeToward(int16_t current, int16_t target)
     return next < target ? target : next;
 }
 
-void configureDriver(DriverState &state, const DriverPins &pins,
-                     uint8_t forwardChannel, uint8_t reverseChannel, uint8_t timer)
+void configureDriver(size_t index, const DriverPins &pins)
 {
+    DriverState &state = drivers[index];
     state.pins = pins;
-    state.forwardChannel = forwardChannel;
-    state.reverseChannel = reverseChannel;
-    state.timer = timer;
     state.initialised = true;
+
+    pinMode(pins.forwardPin, OUTPUT);
+    digitalWrite(pins.forwardPin, LOW);
+    pinMode(pins.reversePin, OUTPUT);
+    digitalWrite(pins.reversePin, LOW);
 
     if (pins.enablePin >= 0) {
         pinMode(pins.enablePin, OUTPUT);
         digitalWrite(pins.enablePin, LOW);
     }
 
-    ledcSetup(timer, LEDC_BASE_FREQ, LEDC_RESOLUTION);
-    ledcAttachPin(pins.forwardPin, forwardChannel);
-    ledcAttachPin(pins.reversePin, reverseChannel);
-    ledcWrite(forwardChannel, 0);
-    ledcWrite(reverseChannel, 0);
+    pwmStates[index].periodTicks = computePeriodTicks(PWM_MIN_FREQ);
+    pwmStates[index].onTicks = 0;
+    pwmStates[index].cycleStart = 0;
+    pwmStates[index].nextEvent = DEFAULT_IDLE_INTERVAL;
+    pwmStates[index].phase = PHASE_START;
+    pwmStates[index].activePin = ACTIVE_NONE;
+}
+
+void applyOutput(size_t index, int16_t command)
+{
+    DriverState &state = drivers[index];
+    if (!state.initialised) return;
+
+    float magnitude = fabsf(static_cast<float>(command) / 1000.0f);
+    magnitude = constrain(magnitude, 0.0f, 1.0f);
+    uint32_t freq = computeFrequency(magnitude);
+    uint32_t periodTicks = computePeriodTicks(freq);
+    uint32_t onTicks = static_cast<uint32_t>(static_cast<float>(periodTicks) * magnitude);
+    if (onTicks > periodTicks) onTicks = periodTicks;
+    if (magnitude > 0.0f && onTicks == 0) onTicks = 1;
+
+    uint8_t activePin = ACTIVE_NONE;
+    if (command > 0) {
+        activePin = ACTIVE_FORWARD;
+    } else if (command < 0) {
+        activePin = ACTIVE_REVERSE;
+    }
+
+    if (state.pins.enablePin >= 0) {
+        digitalWrite(state.pins.enablePin,
+                     (activePin != ACTIVE_NONE && onTicks > 0) ? HIGH : LOW);
+    }
+
+    if (!pwmTimer) {
+        setPinLevel(state.pins.forwardPin,
+                    (activePin == ACTIVE_FORWARD && onTicks > 0) ? HIGH : LOW);
+        setPinLevel(state.pins.reversePin,
+                    (activePin == ACTIVE_REVERSE && onTicks > 0) ? HIGH : LOW);
+        return;
+    }
+
+    portENTER_CRITICAL(&timerMux);
+    PwmState &pwm = pwmStates[index];
+    pwm.periodTicks = periodTicks;
+    pwm.onTicks = (activePin == ACTIVE_NONE) ? 0 : onTicks;
+    pwm.phase = PHASE_START;
+    pwm.cycleStart = currentTicks;
+    pwm.activePin = (activePin == ACTIVE_NONE || onTicks == 0) ? ACTIVE_NONE : activePin;
+
+    setPinLevel(state.pins.forwardPin, LOW);
+    setPinLevel(state.pins.reversePin, LOW);
+
+    if (pwm.activePin == ACTIVE_NONE) {
+        pwm.nextEvent = currentTicks + periodTicks;
+    } else {
+        pwm.nextEvent = currentTicks;
+        setAlarmIntervalLocked(1);
+    }
+    portEXIT_CRITICAL(&timerMux);
 }
 
 } // namespace
@@ -98,10 +254,20 @@ void Outputs::constrainAll()
 bool init(const DriverPins &lf, const DriverPins &lr,
           const DriverPins &rf, const DriverPins &rr)
 {
-    configureDriver(drivers[0], lf, 0, 1, 0);
-    configureDriver(drivers[1], lr, 2, 3, 1);
-    configureDriver(drivers[2], rf, 4, 5, 2);
-    configureDriver(drivers[3], rr, 6, 7, 3);
+    configureDriver(0, lf);
+    configureDriver(1, lr);
+    configureDriver(2, rf);
+    configureDriver(3, rr);
+
+    currentTicks = 0;
+    alarmInterval = DEFAULT_IDLE_INTERVAL;
+
+    pwmTimer = timerBegin(0, 80, true); // 1 MHz
+    if (!pwmTimer) {
+        return false;
+    }
+    timerAttachInterrupt(pwmTimer, &onPwmTimer, true);
+    setAlarmIntervalLocked(DEFAULT_IDLE_INTERVAL);
 
     subsystemInitialised = true;
     return true;
@@ -111,13 +277,9 @@ void calibrate() {}
 
 void stop()
 {
-    for (auto &driver : drivers) {
-        if (!driver.initialised) continue;
-        ledcWrite(driver.forwardChannel, 0);
-        ledcWrite(driver.reverseChannel, 0);
-        if (driver.pins.enablePin >= 0) {
-            digitalWrite(driver.pins.enablePin, LOW);
-        }
+    for (size_t i = 0; i < 4; ++i) {
+        if (!drivers[i].initialised) continue;
+        applyOutput(i, 0);
     }
 }
 
@@ -136,10 +298,10 @@ void update(bool enabled, Outputs &current, const Outputs &target)
         next.constrainAll();
     }
 
-    applyOutput(drivers[0], next.leftFront);
-    applyOutput(drivers[1], next.leftRear);
-    applyOutput(drivers[2], next.rightFront);
-    applyOutput(drivers[3], next.rightRear);
+    applyOutput(0, next.leftFront);
+    applyOutput(1, next.leftRear);
+    applyOutput(2, next.rightFront);
+    applyOutput(3, next.rightRear);
 
     current = next;
 }


### PR DESCRIPTION
## Summary
- replace the motor driver LEDC usage with a single hardware timer driving software PWM logic
- schedule per-driver PWM edges in an ISR that toggles forward/reverse pins directly
- initialise and control motor outputs through the new timer-backed mechanism while preserving easing behaviour

## Testing
- platformio run *(fails: PlatformIO CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cca60d0f60832abb8e227aa5acf509