### PR TITLE
Support ELITE controller identity

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -19,6 +19,7 @@ enum PairingType : uint8_t {
     SCAN_REQUEST = 0x01,
     DRONE_IDENTITY = 0x02,
     ILITE_IDENTITY = 0x03,
+    ELITE_IDENTITY = 0x05,
     DRONE_ACK = 0x04,
 };
 


### PR DESCRIPTION
## Summary
- accept ELITE controller identity messages by matching either the new type or controller name substring
- reuse this detection in both the ESP-NOW helper and main firmware callback so ELITE speeds update the motors

## Testing
- not run (PlatformIO tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cd590e32b4832aa1e4bfae25db176a